### PR TITLE
fix: address of the receiver in the Payment event

### DIFF
--- a/contracts/Feature.sol
+++ b/contracts/Feature.sol
@@ -538,9 +538,9 @@ contract Feature is Initializable, NativeMetaTransaction, ChainConstants, Contex
     /** @dev To be emitted when a party pays.
      *  @param _transactionID The index of the transaction.
      *  @param _amount The amount paid.
-     *  @param _party The party that paid.
+     *  @param _receiver the receiver of the transaction amount.
      */
-    event Payment(uint256 indexed _transactionID, uint256 _amount, address _party);
+    event Payment(uint256 indexed _transactionID, uint256 _amount, address _receiver);
 
     /** @dev To be emitted when a sender is refunded.
      *  @param _transactionID The index of the transaction.

--- a/contracts/Feature.sol
+++ b/contracts/Feature.sol
@@ -694,7 +694,7 @@ contract Feature is Initializable, NativeMetaTransaction, ChainConstants, Contex
 
         payable(claim.receiver).transfer(transaction.amount + transaction.deposit + claim.receiverFee);
 
-        emit Payment(claim.transactionID, transaction.amount, transaction.sender);
+        emit Payment(claim.transactionID, transaction.amount, claim.receiver);
     }
 
     /**

--- a/contracts/FeatureERC20.sol
+++ b/contracts/FeatureERC20.sol
@@ -686,7 +686,7 @@ contract FeatureERC20 is Initializable, NativeMetaTransaction, ChainConstants, C
         payable(claim.receiver).transfer(transaction.deposit + claim.receiverFee);
         IERC20(transaction.token).transfer(claim.receiver, transaction.amount);
 
-        emit Payment(claim.transactionID, transaction.amount, transaction.sender);
+        emit Payment(claim.transactionID, transaction.amount, claim.receiver);
     }
 
     /**

--- a/contracts/FeatureERC20.sol
+++ b/contracts/FeatureERC20.sol
@@ -520,9 +520,9 @@ contract FeatureERC20 is Initializable, NativeMetaTransaction, ChainConstants, C
     /** @dev To be emitted when a party pays.
      *  @param _transactionID The index of the transaction.
      *  @param _amount The amount paid.
-     *  @param _party The party that paid.
+     *  @param _receiver the receiver of the transaction amount.
      */
-    event Payment(uint256 indexed _transactionID, uint256 _amount, address _party);
+    event Payment(uint256 indexed _transactionID, uint256 _amount, address _receiver);
 
     /** @dev To be emitted when a sender is refunded.
      *  @param _transactionID The index of the transaction.


### PR DESCRIPTION
After we have to deploy these contracts:
- feature.sol
- featureERC20.sol